### PR TITLE
IRF method does always work, even for the first few. So do not show NaNs

### DIFF
--- a/src/transmission-function-irfs.jl
+++ b/src/transmission-function-irfs.jl
@@ -53,7 +53,7 @@ function calculate_Q_and_only(from::Int,
     end
     effect .*= irfs_ortho[:, vars[end]] ./ irfs_ortho[vars[end], vars[end]]
 
-    effect[1:maximum(vars)] .= NaN
+    # effect[1:maximum(vars)] .= NaN
     return effect
 end
 

--- a/test/transmission-function.jl
+++ b/test/transmission-function.jl
@@ -169,36 +169,42 @@ end
     Qbb = read_json_to_matrix("./simulated-svar-k3-p1/Qbb.json")
 
     mat = test1(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[3:end, :]
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 2]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
 
     mat = test2(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[4:end, :]    
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 2]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
 
     mat = test3(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[3:end, :]
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 2]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
 
     mat = test4(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[4:end, :]
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 2]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
 
     mat = test5(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[6:end, :]
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 2]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
 
     mat = test6(irfs, irfs_ortho, B, Qbb)
+    @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))
     mat = mat[6:end, :]
     @test isapprox(mat[:, 1], mat[:, 3]; atol = sqrt(eps()))
     @test isapprox(mat[:, 1], mat[:, 4]; atol = sqrt(eps()))


### PR DESCRIPTION
In the BQbb method we decided to show some responses as NaNs. This was, because the BQbb method is not correct for variables ordered before the last not variable. This is not the case for the IRF method, which is always correct. Thus, we can remove the NaNs in the IRF method. 